### PR TITLE
fix: delete subtasks from task that crashed while processing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -472,6 +472,9 @@ jobs:
           only-summary: ${{ env.REPOSITORY != github.repository }}
 
       - name: Show logs
+        if: ${{ always() }}
+        run: docker cp fluentd:/armonik-logs.json -
+      - name: Upload logs
         if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -480,9 +483,11 @@ jobs:
           tar -czf - monitor/ | aws s3 cp - s3://${{ secrets.AWS_LOG_BUCKET_NAME }}/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/stream-${{ matrix.queue }}-${{ matrix.log-level }}-monitor.tar.gz
       - name: Collect docker container logs
         uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e # v2
-        if: ${{ always() && env.REPOSITORY == github.repository }}
         with:
           dest: './container-logs'
+      - name: Show docker container logs
+        if: ${{ always() }}
+        run: find ./container-logs -type f -name "*.log" -exec echo "===== {} =====" \; -exec cat "{}" \;
       - name: Upload docker container logs
         if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |
@@ -685,6 +690,9 @@ jobs:
           time curl localhost:5003/metrics
 
       - name: Show logs
+        if: ${{ always() }}
+        run: docker cp fluentd:/armonik-logs.json -
+      - name: Upload logs
         if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -693,10 +701,13 @@ jobs:
           tar -czf - monitor/ | aws s3 cp - s3://${{ secrets.AWS_LOG_BUCKET_NAME }}/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/htcmock-${{ matrix.target.queue }}-${{ matrix.target.object }}-${{ matrix.target.log-level }}-${{ matrix.target.socket_type }}-${{ matrix.target.cinit }}-monitor.tar.gz
 
       - name: Collect docker container logs
+        if: ${{ always() }}
         uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e # v2
-        if: ${{ always() && env.REPOSITORY == github.repository }}
         with:
           dest: './container-logs'
+      - name: Show docker container logs
+        if: ${{ always() }}
+        run: find ./container-logs -type f -name "*.log" -exec echo "===== {} =====" \; -exec cat "{}" \;
       - name: Upload docker container logs
         if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |
@@ -870,11 +881,15 @@ jobs:
             dockerhubaneo/armonik_core_htcmock_test_client:$env:VERSION
 
       - name: Collect docker container logs
+        if: ${{ always() }}
         uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e # v2
-        if: ${{ always() && env.REPOSITORY == github.repository }}
         with:
           dest: 'container-logs'
           shell: powershell
+      - name: Show docker container logs
+        if: ${{ always() }}
+        run: find ./container-logs -type f -name "*.log" -exec echo "===== {} =====" \; -exec cat "{}" \;
+        shell: bash
       - name: Zip docker container logs
         if: ${{ always() && env.REPOSITORY == github.repository }}
         run: 7z a logs.7z container-logs
@@ -966,16 +981,22 @@ jobs:
           only-summary: ${{ env.REPOSITORY != github.repository }}
 
       - name: Show logs
+        if: ${{ always() }}
+        run: docker cp fluentd:/armonik-logs.json -
+      - name: Upload logs
         if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
           docker cp fluentd:/armonik-logs.json - | gzip -c | aws s3 cp - s3://${{ secrets.AWS_LOG_BUCKET_NAME }}/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/connectivity-ca${{ matrix.ca }}.json.gz
       - name: Collect docker container logs
+        if: ${{ always() }}
         uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e # v2
-        if: ${{ always() && env.REPOSITORY == github.repository }}
         with:
           dest: './container-logs'
+      - name: Show docker container logs
+        if: ${{ always() }}
+        run: find ./container-logs -type f -name "*.log" -exec echo "===== {} =====" \; -exec cat "{}" \;
       - name: Upload docker container logs
         if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |
@@ -1107,6 +1128,9 @@ jobs:
             -e GrpcClient__Endpoint=http://armonik.control.submitter:1080 \
             dockerhubaneo/armonik_core_bench_test_client:$VERSION
       - name: Show logs
+        if: ${{ always() }}
+        run: docker cp fluentd:/armonik-logs.json -
+      - name: Upload logs
         if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -1114,10 +1138,13 @@ jobs:
           docker cp fluentd:/armonik-logs.json - | gzip -c | aws s3 cp - s3://${{ secrets.AWS_LOG_BUCKET_NAME }}/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/runBench-${{ matrix.runner }}.json.gz
           tar -czf - monitor/ | aws s3 cp - s3://${{ secrets.AWS_LOG_BUCKET_NAME }}/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/runBench-${{ matrix.runner }}-monitor.tar.gz
       - name: Collect docker container logs
+        if: ${{ always() }}
         uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e # v2
-        if: ${{ always() && env.REPOSITORY == github.repository }}
         with:
           dest: './container-logs'
+      - name: Show docker container logs
+        if: ${{ always() }}
+        run: find ./container-logs -type f -name "*.log" -exec echo "===== {} =====" \; -exec cat "{}" \;
       - name: Upload docker container logs
         if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |
@@ -1189,6 +1216,9 @@ jobs:
             dockerhubaneo/armonik_core_crashingworker_test_client:$VERSION
 
       - name: Show logs
+        if: ${{ always() }}
+        run: docker cp fluentd:/armonik-logs.json -
+      - name: Upload logs
         if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -1196,10 +1226,13 @@ jobs:
           docker cp fluentd:/armonik-logs.json - | gzip -c | aws s3 cp - s3://${{ secrets.AWS_LOG_BUCKET_NAME }}/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/runCrash.json.gz
           tar -czf - monitor/ | aws s3 cp - s3://${{ secrets.AWS_LOG_BUCKET_NAME }}/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/runCrash-monitor.tar.gz
       - name: Collect docker container logs
+        if: ${{ always() }}
         uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e # v2
-        if: ${{ always() && env.REPOSITORY == github.repository }}
         with:
           dest: './container-logs'
+      - name: Show docker container logs
+        if: ${{ always() }}
+        run: find ./container-logs -type f -name "*.log" -exec echo "===== {} =====" \; -exec cat "{}" \;
       - name: Upload docker container logs
         if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |
@@ -1279,6 +1312,9 @@ jobs:
             dockerhubaneo/armonik_core_htcmock_test_client:$VERSION
 
       - name: Show logs
+        if: ${{ always() }}
+        run: docker cp fluentd:/armonik-logs.json -
+      - name: Upload logs
         if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -1286,10 +1322,13 @@ jobs:
           docker cp fluentd:/armonik-logs.json - | gzip -c | aws s3 cp - s3://${{ secrets.AWS_LOG_BUCKET_NAME }}/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/htcmock-defaultpartition.json.gz
           tar -czf - monitor/ | aws s3 cp - s3://${{ secrets.AWS_LOG_BUCKET_NAME }}/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/htcmock-defaultPartition-monitor.tar.gz
       - name: Collect docker container logs
+        if: ${{ always() }}
         uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e # v2
-        if: ${{ always() && env.REPOSITORY == github.repository }}
         with:
           dest: './container-logs'
+      - name: Show docker container logs
+        if: ${{ always() }}
+        run: find ./container-logs -type f -name "*.log" -exec echo "===== {} =====" \; -exec cat "{}" \;
       - name: Upload docker container logs
         if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |
@@ -1433,6 +1472,9 @@ jobs:
             dockerhubaneo/armonik_core_htcmock_test_client:$VERSION
 
       - name: Show logs
+        if: ${{ always() }}
+        run: docker cp fluentd:/armonik-logs.json -
+      - name: Upload logs
         if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -1440,10 +1482,13 @@ jobs:
           docker cp fluentd:/armonik-logs.json - | gzip -c | aws s3 cp - s3://${{ secrets.AWS_LOG_BUCKET_NAME }}/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/htcmock-healthchecktest.json.gz
           tar -czf - monitor/ | aws s3 cp - s3://${{ secrets.AWS_LOG_BUCKET_NAME }}/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/htcmock-healthchecktest-monitor.tar.gz
       - name: Collect docker container logs
+        if: ${{ always() }}
         uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e # v2
-        if: ${{ always() && env.REPOSITORY == github.repository }}
         with:
           dest: './container-logs'
+      - name: Show docker container logs
+        if: ${{ always() }}
+        run: find ./container-logs -type f -name "*.log" -exec echo "===== {} =====" \; -exec cat "{}" \;
       - name: Upload docker container logs
         if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -751,9 +751,42 @@ jobs:
       - name: Build images
         if: ${{ env.REPOSITORY != github.repository }}
         run: |
-          just tag=$env:VERSION worker=htcmock build-all
-          just tag=$env:VERSION buildHtcmockClient
-        shell: powershell
+          build() {
+            local target dockerfile context name
+            target="${1:-}"
+            name="dockerhubaneo/${2}:${VERSION}"
+            dockerfile="${3:-./Dockerfile}"
+            awk '
+              /^FROM/ {
+                skip = ($0 ~ /linux|tini/)
+              }
+              !skip {
+                gsub(/--platform=[^ ]* /, "");
+                gsub(/\$\{(BUILD|TARGET)OS\}/, "windows");
+                print
+              }' "$dockerfile" > "$dockerfile.win"
+            docker build \
+              ${target:+--target "$target"} \
+              --build-arg VERSION="$VERSION" \
+              --build-arg BUILDOS="windows" \
+              --build-arg TARGETOS="windows" \
+              --build-arg BUILDARCH="amd64" \
+              --build-arg TARGETARCH="amd64" \
+              -t "$name" \
+              -f "$dockerfile.win" \
+              ./
+          }
+
+          set -x
+
+          build polling_agent     armonik_pollingagent
+          build metrics           armonik_control_metrics
+          build partition_metrics armonik_control_partition_metrics
+          build submitter         armonik_control
+
+          build "" armonik_core_htcmock_test_worker ./Tests/HtcMock/Server/src/Dockerfile
+          build "" armonik_core_htcmock_test_client ./Tests/HtcMock/Client/src/Dockerfile
+        shell: bash
 
       - name: Deploy Core
         run: just -v tag=$env:VERSION object=local worker=htcmock ingress=false prometheus=false grafana=false seq=false queue=nats deploy

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,10 @@ on:
       - main
       - releases/*
 
+env:
+  REPOSITORY: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+  REFERENCE: ${{ github.head_ref || github.ref }}
+
 jobs:
   versionning:
     name: Versionning
@@ -23,8 +27,8 @@ jobs:
     - name: Checkout
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       with:
-        repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-        ref: ${{ github.head_ref || github.ref }}
+        repository: ${{ env.REPOSITORY }}
+        ref: ${{ env.REFERENCE }}
         fetch-depth: 0
 
     - name: Generate Version
@@ -55,8 +59,8 @@ jobs:
     - name: Checkout
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       with:
-        repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-        ref: ${{ github.head_ref || github.ref }}
+        repository: ${{ env.REPOSITORY }}
+        ref: ${{ env.REFERENCE }}
 
     - name: Install AWSCLI (the one in the Github runner does not work)
       run: |
@@ -80,11 +84,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y mongodb-org
 
-    - name: Login to Docker Hub
-      uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
-      with:
-        username: ${{ secrets.DOCKER_HUB_LOGIN }}
-        password: ${{ secrets.DOCKER_HUB_TOKEN }}
+    - name: Use GCR cache
+      run: |
+        cat <<EOF | sudo tee /etc/docker/daemon.json
+        {
+          "registry-mirrors": ["https://mirror.gcr.io"]
+        }
+        EOF
+        sudo systemctl restart docker
 
     - name: Minio Server UP
       if: ${{ matrix.projects }} == "Adaptors/S3/tests"
@@ -108,14 +115,15 @@ jobs:
             dotnet test --logger "trx;LogFileName=test-results.trx" -p:RunAnalyzers=false -p:WarningLevel=0
 
     - name: Test Report
-      uses: dorny/test-reporter@v1
-      if: success() || failure()
+      uses: dorny/test-reporter@v2.5.0
+      if: ${{ success() || failure() }}
       with:
         name: Test - ${{ matrix.os }} ${{ matrix.projects }}
         path: ${{ matrix.projects }}/TestResults/test-results.trx
         reporter: dotnet-trx
+        only-summary: ${{ env.REPOSITORY != github.repository }}
     - name: Upload monitor profile
-      if: always()
+      if: ${{ always() && env.REPOSITORY == github.repository }}
       run: |
         export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
         export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -137,8 +145,8 @@ jobs:
     - name: Checkout
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       with:
-        repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-        ref: ${{ github.head_ref || github.ref }}
+        repository: ${{ env.REPOSITORY }}
+        ref: ${{ env.REFERENCE }}
 
     - name: Install AWSCLI (the one in the Github runner does not work)
       run: |
@@ -154,11 +162,14 @@ jobs:
       with:
         tool: just
 
-    - name: Login to Docker Hub
-      uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
-      with:
-        username: ${{ secrets.DOCKER_HUB_LOGIN }}
-        password: ${{ secrets.DOCKER_HUB_TOKEN }}
+    - name: Use GCR cache
+      run: |
+        cat <<EOF | sudo tee /etc/docker/daemon.json
+        {
+          "registry-mirrors": ["https://mirror.gcr.io"]
+        }
+        EOF
+        sudo systemctl restart docker
 
     - name: Set up queue
       run: |
@@ -184,14 +195,15 @@ jobs:
            dotnet test --logger "trx;LogFileName=test-results.trx" -p:RunAnalyzers=false -p:WarningLevel=0
 
     - name: Test Report
-      uses: dorny/test-reporter@v1
-      if: success() || failure()
+      uses: dorny/test-reporter@v2.5.0
+      if: ${{ success() || failure() }}
       with:
         name: Test - ${{ matrix.queue }} Base/tests/Queue
         path: Base/tests/Queue/TestResults/test-results.trx
         reporter: dotnet-trx
+        only-summary: ${{ env.REPOSITORY != github.repository }}
     - name: Upload monitor profile
-      if: always()
+      if: ${{ always() && env.REPOSITORY == github.repository }}
       run: |
         export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
         export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -213,8 +225,8 @@ jobs:
     - name: Checkout
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       with:
-        repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-        ref: ${{ github.head_ref || github.ref }}
+        repository: ${{ env.REPOSITORY }}
+        ref: ${{ env.REFERENCE }}
 
     - name: Install .NET Core
       uses: actions/setup-dotnet@2016bd2012dba4e32de620c46fe006a3ac9f0602 # v5
@@ -233,12 +245,13 @@ jobs:
         dotnet test --logger "trx;LogFileName=test-results.trx" -p:RunAnalyzers=false -p:WarningLevel=0
 
     - name: Test Report
-      uses: dorny/test-reporter@v1
-      if: success() || failure()
+      uses: dorny/test-reporter@v2.5.0
+      if: ${{ success() || failure() }}
       with:
         name: Test - windows ${{ matrix.projects }}
         path: ${{ matrix.projects }}/TestResults/test-results.trx
         reporter: dotnet-trx
+        only-summary: ${{ env.REPOSITORY != github.repository }}
 
   buildProjects:
     runs-on: ubuntu-latest
@@ -246,8 +259,8 @@ jobs:
     - name: Checkout
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       with:
-        repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-        ref: ${{ github.head_ref || github.ref }}
+        repository: ${{ env.REPOSITORY }}
+        ref: ${{ env.REFERENCE }}
 
     - name: Build the solution
       run: dotnet build ArmoniK.Core.sln -c Release -warnAsError:"CS1570;CS1571;CS1572;CS1573;CS1587;CS1591"
@@ -263,8 +276,8 @@ jobs:
     - name: Checkout
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       with:
-        repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-        ref: ${{ github.head_ref || github.ref }}
+        repository: ${{ env.REPOSITORY }}
+        ref: ${{ env.REFERENCE }}
 
     - name: Build the package
       run: |
@@ -275,8 +288,8 @@ jobs:
         dotnet pack Base/src/ArmoniK.Core.Base.csproj -c Release -o /tmp/packages -p:PackageVersion=$VERSION -p:Version=$VERSION
 
     - name: Push the package
+      if: ${{ always() && env.REPOSITORY == github.repository }}
       run: dotnet nuget push /tmp/packages/ArmoniK.Core.*.nupkg --skip-duplicate -k ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
-
 
   images:
     runs-on: ubuntu-latest
@@ -299,8 +312,8 @@ jobs:
     - name: Checkout
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       with:
-        repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-        ref: ${{ github.head_ref || github.ref }}
+        repository: ${{ env.REPOSITORY }}
+        ref: ${{ env.REFERENCE }}
 
     - name: Set up Docker Buildx
       id: buildx
@@ -311,13 +324,24 @@ jobs:
       with:
         tool: just
 
+    - name: Use GCR cache
+      run: |
+        cat <<EOF | sudo tee /etc/docker/daemon.json
+        {
+          "registry-mirrors": ["https://mirror.gcr.io"]
+        }
+        EOF
+        sudo systemctl restart docker
+
     - name: Login to Docker Hub
       uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
+      if: ${{ always() && env.REPOSITORY == github.repository }}
       with:
         username: ${{ secrets.DOCKER_HUB_LOGIN }}
         password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
     - name: Build
+      if: ${{ always() && env.REPOSITORY == github.repository }}
       run: |
         tools/retry.sh -w 60 -r 2 -- just tag=$VERSION platform=linux/arm64,linux/amd64,windows/amd64 load=false push=true ${{ matrix.type }}
 
@@ -343,19 +367,21 @@ jobs:
     steps:
     - name: Login to Docker Hub
       uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
+      if: ${{ env.REPOSITORY == github.repository }}
       with:
         username: ${{ secrets.DOCKER_HUB_LOGIN }}
         password: ${{ secrets.DOCKER_HUB_TOKEN }}
     - name: Analyze for critical and high CVEs
       uses: docker/scout-action@f8c776824083494ab0d56b8105ba2ca85c86e4de # v1
+      if: ${{ env.REPOSITORY == github.repository }}
       with:
         command: cves
         image: "${{ matrix.image }}:${{ needs.versionning.outputs.version }}"
         sarif-file: sarif.output.json
         summary: true
     - name: print sarif file
+      if: ${{ env.REPOSITORY == github.repository }}
       run: cat sarif.output.json
-
 
   testStreamDC:
     needs:
@@ -381,8 +407,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.head_ref || github.ref }}
+          repository: ${{ env.REPOSITORY }}
+          ref: ${{ env.REFERENCE }}
 
       - name: Install AWSCLI (the one in the Github runner does not work)
         run: |
@@ -398,11 +424,19 @@ jobs:
         with:
           terraform_version: latest
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
-        with:
-          username: ${{ secrets.DOCKER_HUB_LOGIN }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - name: Use GCR cache
+        run: |
+          cat <<EOF | sudo tee /etc/docker/daemon.json
+          {
+            "registry-mirrors": ["https://mirror.gcr.io"]
+          }
+          EOF
+          sudo systemctl restart docker
+
+      - name: Build images
+        if: ${{ env.REPOSITORY != github.repository }}
+        run: |
+          tools/retry.sh -w 60 -r 2 -- just tag=${VERSION} worker=stream build-all
 
       - name: Deploy Core
         run: |
@@ -429,15 +463,16 @@ jobs:
             dotnet test --logger "trx;LogFileName=test-results.trx" -p:RunAnalyzers=false -p:WarningLevel=0
 
       - name: Test Report
-        uses: dorny/test-reporter@v1
-        if: success() || failure()
+        uses: dorny/test-reporter@v2.5.0
+        if: ${{ success() || failure() }}
         with:
           name: Test - ${{ matrix.queue }} x ${{ matrix.log-level }}
           path: ./Tests/Stream/Client/TestResults/test-results.trx
           reporter: dotnet-trx
+          only-summary: ${{ env.REPOSITORY != github.repository }}
 
       - name: Show logs
-        if: always()
+        if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -445,23 +480,22 @@ jobs:
           tar -czf - monitor/ | aws s3 cp - s3://${{ secrets.AWS_LOG_BUCKET_NAME }}/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/stream-${{ matrix.queue }}-${{ matrix.log-level }}-monitor.tar.gz
       - name: Collect docker container logs
         uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e # v2
-        if: always()
+        if: ${{ always() && env.REPOSITORY == github.repository }}
         with:
           dest: './container-logs'
       - name: Upload docker container logs
-        if: always()
+        if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
           tar -cvf - ./container-logs | aws s3 cp - s3://${{ secrets.AWS_LOG_BUCKET_NAME }}/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/stream-${{ matrix.queue }}-${{ matrix.log-level }}-container-logs.tar.gz
       - name: Export and upload database
-        if: always()
+        if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
           bash tools/export_mongodb.sh
           tar -cvf - *.json | aws s3 cp - s3://${{ secrets.AWS_LOG_BUCKET_NAME }}/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/stream-${{ matrix.queue }}-${{ matrix.log-level }}-database.tar.gz
-
 
   testHtcMockDC:
     needs:
@@ -512,8 +546,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.head_ref || github.ref }}
+          repository: ${{ env.REPOSITORY }}
+          ref: ${{ env.REFERENCE }}
 
       - name: Install AWSCLI (the one in the Github runner does not work)
         run: |
@@ -529,11 +563,20 @@ jobs:
         with:
           terraform_version: latest
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
-        with:
-          username: ${{ secrets.DOCKER_HUB_LOGIN }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - name: Use GCR cache
+        run: |
+          cat <<EOF | sudo tee /etc/docker/daemon.json
+          {
+            "registry-mirrors": ["https://mirror.gcr.io"]
+          }
+          EOF
+          sudo systemctl restart docker
+
+      - name: Build images
+        if: ${{ env.REPOSITORY != github.repository }}
+        run: |
+          tools/retry.sh -w 60 -r 2 -- just tag=${VERSION} worker=htcmock build-all
+          tools/retry.sh -w 60 -r 2 -- just tag=${VERSION} buildHtcmockClient
 
       - name: Deploy Core
         run: |
@@ -642,7 +685,7 @@ jobs:
           time curl localhost:5003/metrics
 
       - name: Show logs
-        if: always()
+        if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -651,17 +694,17 @@ jobs:
 
       - name: Collect docker container logs
         uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e # v2
-        if: always()
+        if: ${{ always() && env.REPOSITORY == github.repository }}
         with:
           dest: './container-logs'
       - name: Upload docker container logs
-        if: always()
+        if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
           tar -cvf - ./container-logs | aws s3 cp - s3://${{ secrets.AWS_LOG_BUCKET_NAME }}/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/htcmock-${{ matrix.target.queue }}-${{ matrix.target.object }}-${{ matrix.target.log-level }}-${{ matrix.target.socket_type }}-${{ matrix.target.cinit }}-container-logs.tar.gz
       - name: Export and upload database
-        if: always()
+        if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -680,8 +723,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.head_ref || github.ref }}
+          repository: ${{ env.REPOSITORY }}
+          ref: ${{ env.REFERENCE }}
 
       - name: Setup Terraform and other tools
         run: |
@@ -692,6 +735,7 @@ jobs:
 
       - name: Setup AWS cli
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
+        if: ${{ env.REPOSITORY == github.repository }}
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -699,15 +743,24 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
+        if: ${{ env.REPOSITORY == github.repository }}
         with:
           username: ${{ secrets.DOCKER_HUB_LOGIN }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Build images
+        if: ${{ env.REPOSITORY != github.repository }}
+        run: |
+          just tag=$env:VERSION worker=htcmock build-all
+          just tag=$env:VERSION buildHtcmockClient
+        shell: powershell
 
       - name: Deploy Core
         run: just -v tag=$env:VERSION object=local worker=htcmock ingress=false prometheus=false grafana=false seq=false queue=nats deploy
         shell: powershell
 
       - name: Pull image
+        if: ${{ env.REPOSITORY == github.repository }}
         run: docker pull dockerhubaneo/armonik_core_htcmock_test_client:$env:VERSION
         timeout-minutes: 10
         shell: powershell
@@ -785,18 +838,18 @@ jobs:
 
       - name: Collect docker container logs
         uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e # v2
-        if: always()
+        if: ${{ always() && env.REPOSITORY == github.repository }}
         with:
           dest: 'container-logs'
           shell: powershell
       - name: Zip docker container logs
-        if: always()
+        if: ${{ always() && env.REPOSITORY == github.repository }}
         run: 7z a logs.7z container-logs
       - name: Upload docker container logs
-        if: always()
+        if: ${{ always() && env.REPOSITORY == github.repository }}
         run: aws s3 cp logs.7z s3://${{ secrets.AWS_LOG_BUCKET_NAME }}/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/docker-windows-container-logs.7z
       - name: Upload armonik logs
-        if: always()
+        if: ${{ always() && env.REPOSITORY == github.repository }}
         run: docker cp fluentd:/armonik-logs.json - | gzip -c | aws s3 cp - s3://${{ secrets.AWS_LOG_BUCKET_NAME }}/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/docker-windows-armonik-logs.json.gz
 
   testConnectivity:
@@ -815,8 +868,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.head_ref || github.ref }}
+          repository: ${{ env.REPOSITORY }}
+          ref: ${{ env.REFERENCE }}
 
       - name: Install AWSCLI (the one in the Github runner does not work)
         run: |
@@ -832,11 +885,20 @@ jobs:
         with:
           terraform_version: latest
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
-        with:
-          username: ${{ secrets.DOCKER_HUB_LOGIN }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - name: Use GCR cache
+        run: |
+          cat <<EOF | sudo tee /etc/docker/daemon.json
+          {
+            "registry-mirrors": ["https://mirror.gcr.io"]
+          }
+          EOF
+          sudo systemctl restart docker
+
+      - name: Build images
+        if: ${{ env.REPOSITORY != github.repository }}
+        run: |
+          tools/retry.sh -w 60 -r 2 -- just tag=${VERSION} build-all
+          tools/retry.sh -w 60 -r 2 -- just tag=${VERSION} buildHtcmockClient
 
       - name: Deploy Core
         run: |
@@ -862,32 +924,33 @@ jobs:
         run: CA_INSTALLED=${{ matrix.ca }} dotnet test Tests/Connectivity/src/ArmoniK.Core.Tests.Connectivity.csproj --logger "trx;LogFileName=test-results.trx" -p:RunAnalyzers=false -p:WarningLevel=0
 
       - name: Test Report
-        uses: dorny/test-reporter@v1
-        if: always()
+        uses: dorny/test-reporter@v2.5.0
+        if: ${{ success() || failure() }}
         with:
           name: Test - Connectivity CA ${{ matrix.ca }}
           path: ./Tests/Connectivity/src/TestResults/test-results.trx
           reporter: dotnet-trx
+          only-summary: ${{ env.REPOSITORY != github.repository }}
 
       - name: Show logs
-        if: always()
+        if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
           docker cp fluentd:/armonik-logs.json - | gzip -c | aws s3 cp - s3://${{ secrets.AWS_LOG_BUCKET_NAME }}/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/connectivity-ca${{ matrix.ca }}.json.gz
       - name: Collect docker container logs
         uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e # v2
-        if: always()
+        if: ${{ always() && env.REPOSITORY == github.repository }}
         with:
           dest: './container-logs'
       - name: Upload docker container logs
-        if: always()
+        if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
           tar -cvf - ./container-logs | aws s3 cp - s3://${{ secrets.AWS_LOG_BUCKET_NAME }}/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/connectivity-ca${{ matrix.ca }}-container-logs.tar.gz
       - name: Export and upload database
-        if: always()
+        if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -912,8 +975,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.head_ref || github.ref }}
+          repository: ${{ env.REPOSITORY }}
+          ref: ${{ env.REFERENCE }}
 
       - name: Install AWSCLI (the one in the Github runner does not work)
         run: |
@@ -929,11 +992,20 @@ jobs:
         with:
           terraform_version: latest
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
-        with:
-          username: ${{ secrets.DOCKER_HUB_LOGIN }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - name: Use GCR cache
+        run: |
+          cat <<EOF | sudo tee /etc/docker/daemon.json
+          {
+            "registry-mirrors": ["https://mirror.gcr.io"]
+          }
+          EOF
+          sudo systemctl restart docker
+
+      - name: Build images
+        if: ${{ env.REPOSITORY != github.repository }}
+        run: |
+          tools/retry.sh -w 60 -r 2 -- just tag=${VERSION} worker=bench build-all
+          tools/retry.sh -w 60 -r 2 -- just tag=${VERSION} buildBenchClient
 
       - name: Deploy Core
         run: |
@@ -1002,7 +1074,7 @@ jobs:
             -e GrpcClient__Endpoint=http://armonik.control.submitter:1080 \
             dockerhubaneo/armonik_core_bench_test_client:$VERSION
       - name: Show logs
-        if: always()
+        if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -1010,23 +1082,22 @@ jobs:
           tar -czf - monitor/ | aws s3 cp - s3://${{ secrets.AWS_LOG_BUCKET_NAME }}/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/runBench-${{ matrix.runner }}-monitor.tar.gz
       - name: Collect docker container logs
         uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e # v2
-        if: always()
+        if: ${{ always() && env.REPOSITORY == github.repository }}
         with:
           dest: './container-logs'
       - name: Upload docker container logs
-        if: always()
+        if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
           tar -cvf - ./container-logs | aws s3 cp - s3://${{ secrets.AWS_LOG_BUCKET_NAME }}/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/runBench-${{ matrix.runner }}-container-logs.tar.gz
       - name: Export and upload database
-        if: always()
+        if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
           bash tools/export_mongodb.sh
           tar -cvf - *.json | aws s3 cp - s3://${{ secrets.AWS_LOG_BUCKET_NAME }}/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/runBench-${{ matrix.runner }}-database.tar.gz
-
 
   runCrash:
     needs:
@@ -1039,8 +1110,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.head_ref || github.ref }}
+          repository: ${{ env.REPOSITORY }}
+          ref: ${{ env.REFERENCE }}
 
       - name: Install AWSCLI (the one in the Github runner does not work)
         run: |
@@ -1056,11 +1127,14 @@ jobs:
         with:
           terraform_version: latest
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
-        with:
-          username: ${{ secrets.DOCKER_HUB_LOGIN }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - name: Use GCR cache
+        run: |
+          cat <<EOF | sudo tee /etc/docker/daemon.json
+          {
+            "registry-mirrors": ["https://mirror.gcr.io"]
+          }
+          EOF
+          sudo systemctl restart docker
 
       - name: Deploy Core
         run: |
@@ -1082,7 +1156,7 @@ jobs:
             dockerhubaneo/armonik_core_crashingworker_test_client:$VERSION
 
       - name: Show logs
-        if: always()
+        if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -1090,17 +1164,17 @@ jobs:
           tar -czf - monitor/ | aws s3 cp - s3://${{ secrets.AWS_LOG_BUCKET_NAME }}/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/runCrash-monitor.tar.gz
       - name: Collect docker container logs
         uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e # v2
-        if: always()
+        if: ${{ always() && env.REPOSITORY == github.repository }}
         with:
           dest: './container-logs'
       - name: Upload docker container logs
-        if: always()
+        if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
           tar -cvf - ./container-logs | aws s3 cp - s3://${{ secrets.AWS_LOG_BUCKET_NAME }}/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/runCrash-container-logs.tar.gz
       - name: Export and upload database
-        if: always()
+        if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -1120,8 +1194,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.head_ref || github.ref }}
+          repository: ${{ env.REPOSITORY }}
+          ref: ${{ env.REFERENCE }}
 
       - name: Install AWSCLI (the one in the Github runner does not work)
         run: |
@@ -1137,11 +1211,20 @@ jobs:
         with:
           terraform_version: latest
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
-        with:
-          username: ${{ secrets.DOCKER_HUB_LOGIN }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - name: Use GCR cache
+        run: |
+          cat <<EOF | sudo tee /etc/docker/daemon.json
+          {
+            "registry-mirrors": ["https://mirror.gcr.io"]
+          }
+          EOF
+          sudo systemctl restart docker
+
+      - name: Build images
+        if: ${{ env.REPOSITORY != github.repository }}
+        run: |
+          tools/retry.sh -w 60 -r 2 -- just tag=${VERSION} worker=htcmock build-all
+          tools/retry.sh -w 60 -r 2 -- just tag=${VERSION} buildHtcmockClient
 
       - name: Deploy Core
         run: |
@@ -1163,7 +1246,7 @@ jobs:
             dockerhubaneo/armonik_core_htcmock_test_client:$VERSION
 
       - name: Show logs
-        if: always()
+        if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -1171,17 +1254,17 @@ jobs:
           tar -czf - monitor/ | aws s3 cp - s3://${{ secrets.AWS_LOG_BUCKET_NAME }}/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/htcmock-defaultPartition-monitor.tar.gz
       - name: Collect docker container logs
         uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e # v2
-        if: always()
+        if: ${{ always() && env.REPOSITORY == github.repository }}
         with:
           dest: './container-logs'
       - name: Upload docker container logs
-        if: always()
+        if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
           tar -cvf - ./container-logs | aws s3 cp - s3://${{ secrets.AWS_LOG_BUCKET_NAME }}/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/htcmock-defaultpartition-container-logs.tar.gz
       - name: Export and upload database
-        if: always()
+        if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -1199,8 +1282,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.head_ref || github.ref }}
+          repository: ${{ env.REPOSITORY }}
+          ref: ${{ env.REFERENCE }}
 
       - name: Install AWSCLI (the one in the Github runner does not work)
         run: |
@@ -1216,11 +1299,20 @@ jobs:
         with:
           terraform_version: latest
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
-        with:
-          username: ${{ secrets.DOCKER_HUB_LOGIN }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - name: Use GCR cache
+        run: |
+          cat <<EOF | sudo tee /etc/docker/daemon.json
+          {
+            "registry-mirrors": ["https://mirror.gcr.io"]
+          }
+          EOF
+          sudo systemctl restart docker
+
+      - name: Build images
+        if: ${{ env.REPOSITORY != github.repository }}
+        run: |
+          tools/retry.sh -w 60 -r 2 -- just tag=${VERSION} build-all
+          tools/retry.sh -w 60 -r 2 -- just tag=${VERSION} buildHtcmockClient
 
       - name: Deploy Core
         run: |
@@ -1308,7 +1400,7 @@ jobs:
             dockerhubaneo/armonik_core_htcmock_test_client:$VERSION
 
       - name: Show logs
-        if: always()
+        if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -1316,17 +1408,17 @@ jobs:
           tar -czf - monitor/ | aws s3 cp - s3://${{ secrets.AWS_LOG_BUCKET_NAME }}/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/htcmock-healthchecktest-monitor.tar.gz
       - name: Collect docker container logs
         uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e # v2
-        if: always()
+        if: ${{ always() && env.REPOSITORY == github.repository }}
         with:
           dest: './container-logs'
       - name: Upload docker container logs
-        if: always()
+        if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
           tar -cvf - ./container-logs | aws s3 cp - s3://${{ secrets.AWS_LOG_BUCKET_NAME }}/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/htcmock-healthchecktest-container-logs.tar.gz
       - name: Export and upload database
-        if: always()
+        if: ${{ always() && env.REPOSITORY == github.repository }}
         run: |
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/Adaptors/Embed/src/ObjectStorage.cs
+++ b/Adaptors/Embed/src/ObjectStorage.cs
@@ -23,6 +23,7 @@ using System.Threading.Tasks;
 
 using ArmoniK.Core.Base;
 using ArmoniK.Core.Base.DataStructures;
+using ArmoniK.Core.Utils;
 
 using JetBrains.Annotations;
 
@@ -88,5 +89,6 @@ public class ObjectStorage : IObjectStorage
   public Task<IDictionary<byte[], long?>> GetSizesAsync(IEnumerable<byte[]> ids,
                                                         CancellationToken   cancellationToken = default)
     => Task.FromResult<IDictionary<byte[], long?>>(ids.ToDictionary(id => id,
-                                                                    id => (long?)id.LongLength));
+                                                                    id => (long?)id.LongLength,
+                                                                    new ByteArrayComparer()));
 }

--- a/Adaptors/LocalStorage/src/ObjectStorage.cs
+++ b/Adaptors/LocalStorage/src/ObjectStorage.cs
@@ -27,6 +27,7 @@ using System.Threading.Tasks;
 using ArmoniK.Core.Base;
 using ArmoniK.Core.Base.DataStructures;
 using ArmoniK.Core.Base.Exceptions;
+using ArmoniK.Core.Utils;
 
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
@@ -206,7 +207,8 @@ public class ObjectStorage : IObjectStorage
                                                         CancellationToken   cancellationToken = default)
     => Task.FromResult<IDictionary<byte[], long?>>(ids.ToDictionary(id => id,
                                                                     id => GetFileSize(Path.Combine(path_,
-                                                                                                   Encoding.UTF8.GetString(id)))));
+                                                                                                   Encoding.UTF8.GetString(id))),
+                                                                    new ByteArrayComparer()));
 
 
   private static long? GetFileSize(string filename)

--- a/Adaptors/Memory/src/ObjectStorage.cs
+++ b/Adaptors/Memory/src/ObjectStorage.cs
@@ -27,6 +27,7 @@ using System.Threading.Tasks;
 using ArmoniK.Core.Base;
 using ArmoniK.Core.Base.DataStructures;
 using ArmoniK.Core.Base.Exceptions;
+using ArmoniK.Core.Utils;
 using ArmoniK.Utils;
 
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -110,7 +111,8 @@ public class ObjectStorage : IObjectStorage
   public Task<IDictionary<byte[], long?>> GetSizesAsync(IEnumerable<byte[]> ids,
                                                         CancellationToken   cancellationToken = default)
     => Task.FromResult<IDictionary<byte[], long?>>(ids.ToDictionary(id => id,
-                                                                    Exists));
+                                                                    Exists,
+                                                                    new ByteArrayComparer()));
 
 
   private long? Exists(byte[] id)

--- a/Adaptors/Redis/src/ObjectStorage.cs
+++ b/Adaptors/Redis/src/ObjectStorage.cs
@@ -26,6 +26,7 @@ using System.Threading.Tasks;
 using ArmoniK.Core.Base;
 using ArmoniK.Core.Base.DataStructures;
 using ArmoniK.Core.Base.Exceptions;
+using ArmoniK.Core.Utils;
 using ArmoniK.Utils;
 
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -162,7 +163,9 @@ public class ObjectStorage : IObjectStorage
                                                                    cancellationToken)
                                                    .ConfigureAwait(false)))
                 .ToDictionaryAsync(tuple => tuple.id,
-                                   tuple => tuple.Item2)
+                                   tuple => tuple.Item2,
+                                   new ByteArrayComparer(),
+                                   cancellationToken)
                 .ConfigureAwait(false);
 
   private async Task<long?> ExistsAsync(byte[]            id,

--- a/Adaptors/S3/src/ObjectStorage.cs
+++ b/Adaptors/S3/src/ObjectStorage.cs
@@ -34,6 +34,7 @@ using Amazon.S3.Util;
 using ArmoniK.Core.Base;
 using ArmoniK.Core.Base.DataStructures;
 using ArmoniK.Core.Base.Exceptions;
+using ArmoniK.Core.Utils;
 using ArmoniK.Utils;
 
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -224,7 +225,9 @@ public class ObjectStorage : IObjectStorage
                                                                     cancellationToken)
                                                    .ConfigureAwait(false)))
                 .ToDictionaryAsync(tuple => tuple.id,
-                                   tuple => tuple.Item2)
+                                   tuple => tuple.Item2,
+                                   new ByteArrayComparer(),
+                                   cancellationToken)
                 .ConfigureAwait(false);
 
   private async Task<GetObjectResponse> GetObjectStream(string            key,

--- a/Common/src/Pollster/TaskHandler.cs
+++ b/Common/src/Pollster/TaskHandler.cs
@@ -400,7 +400,7 @@ public sealed class TaskHandler : IAsyncDisposable
                                                   TaskStatus.Cancelled)
                                     .ConfigureAwait(false);
 
-        await ResultLifeCycleHelper.AbortTasksAndResults(taskTable_,
+        await ResultLifeCycleHelper.TerminateTasksAndResults(taskTable_,
                                                          resultTable_,
                                                          new[]
                                                          {
@@ -431,7 +431,7 @@ public sealed class TaskHandler : IAsyncDisposable
                                                     TaskStatus.Cancelled)
                                       .ConfigureAwait(false);
 
-          await ResultLifeCycleHelper.AbortTasksAndResults(taskTable_,
+          await ResultLifeCycleHelper.TerminateTasksAndResults(taskTable_,
                                                            resultTable_,
                                                            new[]
                                                            {
@@ -464,7 +464,7 @@ public sealed class TaskHandler : IAsyncDisposable
         case TaskStatus.Error:
           logger_.LogInformation("Task was on error elsewhere ; task should have been resubmitted");
           messageHandler_.Status = QueueMessageStatus.Cancelled;
-          await ResultLifeCycleHelper.AbortTasksAndResults(taskTable_,
+          await ResultLifeCycleHelper.TerminateTasksAndResults(taskTable_,
                                                            resultTable_,
                                                            new[]
                                                            {
@@ -480,7 +480,7 @@ public sealed class TaskHandler : IAsyncDisposable
         case TaskStatus.Cancelled:
           logger_.LogInformation("Task has been cancelled");
           messageHandler_.Status = QueueMessageStatus.Cancelled;
-          await ResultLifeCycleHelper.AbortTasksAndResults(taskTable_,
+          await ResultLifeCycleHelper.TerminateTasksAndResults(taskTable_,
                                                            resultTable_,
                                                            new[]
                                                            {
@@ -737,7 +737,7 @@ public sealed class TaskHandler : IAsyncDisposable
             taskData_ = await taskTable_.EndTaskAsync(taskData_,
                                                       TaskStatus.Cancelled)
                                         .ConfigureAwait(false);
-            await ResultLifeCycleHelper.AbortTasksAndResults(taskTable_,
+            await ResultLifeCycleHelper.TerminateTasksAndResults(taskTable_,
                                                              resultTable_,
                                                              new[]
                                                              {

--- a/Common/src/Storage/ResultTableExtensions.cs
+++ b/Common/src/Storage/ResultTableExtensions.cs
@@ -154,17 +154,17 @@ public static class ResultTableExtensions
   /// <param name="completedBy">Identifier of the task that completed the results</param>
   /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
   /// <returns>
-  ///   The new version of the result metadata
+  ///   The completion's date
   /// </returns>
   /// <exception cref="ResultNotFoundException">when result to update is not found</exception>
-  public static async Task CompleteManyResults(this IResultTable                                          resultTable,
-                                               ICollection<(string resultId, long size, byte[] opaqueId)> results,
-                                               string                                                     completedBy,
-                                               CancellationToken                                          cancellationToken = default)
+  public static async Task<DateTime?> CompleteManyResults(this IResultTable                                          resultTable,
+                                                          ICollection<(string resultId, long size, byte[] opaqueId)> results,
+                                                          string                                                     completedBy,
+                                                          CancellationToken                                          cancellationToken = default)
   {
     if (results.Count == 0)
     {
-      return;
+      return null;
     }
 
     var now = DateTime.UtcNow;
@@ -180,6 +180,7 @@ public static class ResultTableExtensions
                                                                                                             now))),
                                         cancellationToken)
                      .ConfigureAwait(false);
+    return now;
   }
 
   /// <summary>

--- a/Common/src/Storage/TaskLifeCycleHelper.cs
+++ b/Common/src/Storage/TaskLifeCycleHelper.cs
@@ -711,12 +711,13 @@ public static class TaskLifeCycleHelper
                                           .ToListAsync(cancellationToken)
                                           .ConfigureAwait(false);
 
-    await ResultLifeCycleHelper.AbortTasksAndResults(taskTable,
+    await ResultLifeCycleHelper.TerminateTasksAndResults(taskTable,
                                                      resultTable,
                                                      subtasks,
                                                      resultsToAbort,
                                                      errorMessage,
                                                      TaskStatus.Cancelled,
+                                                     false,
                                                      cancellationToken)
                                .ConfigureAwait(false);
 
@@ -815,7 +816,7 @@ public static class TaskLifeCycleHelper
                                                cancellationToken)
                                  .ConfigureAwait(false);
 
-    await ResultLifeCycleHelper.AbortTasksAndResults(taskTable,
+    await ResultLifeCycleHelper.TerminateTasksAndResults(taskTable,
                                                      resultTable,
                                                      new[]
                                                      {
@@ -1015,13 +1016,14 @@ public static class TaskLifeCycleHelper
                                           .ToListAsync(cancellationToken)
                                           .ConfigureAwait(false);
 
-    await ResultLifeCycleHelper.AbortTasksAndResults(taskTable,
-                                                     resultTable,
-                                                     subtasks.ViewSelect(td => td.TaskId),
-                                                     resultsToAbort,
-                                                     errorMessage,
-                                                     TaskStatus.Cancelled,
-                                                     cancellationToken)
+    await ResultLifeCycleHelper.TerminateTasksAndResults(taskTable,
+                                                          resultTable,
+                                                          subtasks.ViewSelect(td => td.TaskId),
+                                                          resultsToAbort,
+                                                          errorMessage,
+                                                          TaskStatus.Cancelled,
+                                                          true,
+                                                          cancellationToken)
                                .ConfigureAwait(false);
 
     // Retry or abort the current task
@@ -1031,7 +1033,7 @@ public static class TaskLifeCycleHelper
                                         pushQueueStorage,
                                         taskData,
                                         sessionData,
-                                        subtasks.ViewSelect(td => td.TaskId),
+                                        [],
                                         errorMessage,
                                         logger,
                                         cancellationToken)

--- a/Common/src/gRPC/Services/GrpcTasksService.cs
+++ b/Common/src/gRPC/Services/GrpcTasksService.cs
@@ -348,7 +348,7 @@ public class GrpcTasksService : Task.TasksBase
                                         })
                        .ConfigureAwait(false);
 
-      await ResultLifeCycleHelper.AbortTasksAndResults(taskTable_,
+      await ResultLifeCycleHelper.TerminateTasksAndResults(taskTable_,
                                                        resultTable_,
                                                        request.TaskIds,
                                                        reason: $"Client requested cancellation of tasks {string.Join(", ", request.TaskIds)}",

--- a/Common/tests/GrpcResultsServiceTests.cs
+++ b/Common/tests/GrpcResultsServiceTests.cs
@@ -454,7 +454,17 @@ public class GrpcResultsServiceTests
   {
     var resultClient = new Results.ResultsClient(channel_);
 
-    string[] colors = ["blue", "red", "green", "white", "black", "yellow", "cyan", "orange"];
+    var colors = new[]
+                 {
+                   "blue",
+                   "red",
+                   "green",
+                   "white",
+                   "black",
+                   "yellow",
+                   "cyan",
+                   "orange",
+                 };
     var resultRequest = colors.Select(color => new CreateResultsRequest.Types.ResultCreate
                                                {
                                                  Name = color,

--- a/Common/tests/GrpcResultsServiceTests.cs
+++ b/Common/tests/GrpcResultsServiceTests.cs
@@ -18,7 +18,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -555,12 +554,11 @@ public class GrpcResultsServiceTests
   }
 
   [Test]
-  public async Task IssueDuringCreateResultsShouldNotCreateAnything()
+  public void IssueDuringCreateResultsShouldNotCreateAnything()
   {
     var mock = new Mock<IResultTable>();
-    mock.Setup(table => table.GetResults(It.IsAny<Expression<Func<Result, bool>>>(),
-                                         It.IsAny<Expression<Func<Result, Result>>>(),
-                                         It.IsAny<CancellationToken>()))
+    mock.Setup(table => table.Create(It.IsAny<ICollection<Result>>(),
+                                     It.IsAny<CancellationToken>()))
         .Throws<OperationCanceledException>();
 
 

--- a/Common/tests/GrpcResultsServiceTests.cs
+++ b/Common/tests/GrpcResultsServiceTests.cs
@@ -404,8 +404,10 @@ public class GrpcResultsServiceTests
     {
       resultOpaqueIdList.Add(new ImportResultsDataRequest.Types.ResultOpaqueId
                              {
-                               OpaqueId = ByteString.CopyFrom(colorsData[i].id),
-                               ResultId = resultRaw[i].ResultId,
+                               OpaqueId = ByteString.CopyFrom(colorsData[i]
+                                                                .id),
+                               ResultId = resultRaw[i]
+                                 .ResultId,
                              });
     }
 

--- a/Common/tests/GrpcResultsServiceTests.cs
+++ b/Common/tests/GrpcResultsServiceTests.cs
@@ -451,6 +451,31 @@ public class GrpcResultsServiceTests
   }
 
   [Test]
+  public void ImportMultipleDataShouldPreserveOrder()
+  {
+    var resultClient = new Results.ResultsClient(channel_);
+
+    string[] colors = ["blue", "red", "green", "white", "black", "yellow", "cyan", "orange"];
+    var resultRequest = colors.Select(color => new CreateResultsRequest.Types.ResultCreate
+                                               {
+                                                 Name = color,
+                                                 Data = ByteString.CopyFromUtf8(color),
+                                               });
+
+    var resultResponse = resultClient.CreateResults(new CreateResultsRequest
+                                                    {
+                                                      SessionId = session_!.SessionId,
+                                                      Results =
+                                                      {
+                                                        resultRequest,
+                                                      },
+                                                    });
+
+    Assert.That(resultResponse.Results.Select(result => result.Name),
+                Is.EquivalentTo(colors));
+  }
+
+  [Test]
   public async Task PurgeDataShouldSucceed()
   {
     var objectStorage = helper_!.GetRequiredService<IObjectStorage>();

--- a/Common/tests/Helpers/SimpleObjectStorage.cs
+++ b/Common/tests/Helpers/SimpleObjectStorage.cs
@@ -24,6 +24,7 @@ using System.Threading.Tasks;
 
 using ArmoniK.Core.Base;
 using ArmoniK.Core.Base.DataStructures;
+using ArmoniK.Core.Utils;
 
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
@@ -44,7 +45,8 @@ public class SimpleObjectStorage : IObjectStorage
   public Task<IDictionary<byte[], long?>> GetSizesAsync(IEnumerable<byte[]> ids,
                                                         CancellationToken   cancellationToken = default)
     => Task.FromResult<IDictionary<byte[], long?>>(ids.ToDictionary(id => id,
-                                                                    _ => (long?)42));
+                                                                    _ => (long?)42,
+                                                                    new ByteArrayComparer()));
 
   public Task<(byte[] id, long size)> AddOrUpdateAsync(ObjectData                             metaData,
                                                        IAsyncEnumerable<ReadOnlyMemory<byte>> valueChunks,

--- a/Common/tests/TaskLifeCycleHelperTest.cs
+++ b/Common/tests/TaskLifeCycleHelperTest.cs
@@ -1486,20 +1486,22 @@ public class TaskLifeCycleHelperTest
 
                       Assert.That(taskB,
                                   crashState >= CrashState.TasksCreated || !subtask
-                                    ? Has.ItemAt(0)
-                                         .Property("Status")
-                                         .EqualTo(committed || !subtask
-                                                    ? TaskStatus.Pending
-                                                    : TaskStatus.Cancelled)
+                                    ? committed || !subtask
+                                        ? Has.ItemAt(0)
+                                             .Property("Status")
+                                             .EqualTo(TaskStatus.Pending)
+                                        : Is.Empty // subtasks are deleted when not committed
                                     : Is.Empty);
 
                       Assert.That(outputB,
                                   crashState >= CrashState.ResultsCreated || !subtask
-                                    ? Has.ItemAt(0)
-                                         .Property("Status")
-                                         .EqualTo(committed || !subtask
-                                                    ? ResultStatus.Created
-                                                    : ResultStatus.Aborted)
+                                    ? committed || !subtask
+                                        ? Has.ItemAt(0)
+                                             .Property("Status")
+                                             .EqualTo(ResultStatus.Created)
+                                        : Has.ItemAt(0) // results are aborted when not committed
+                                             .Property("Status")
+                                             .EqualTo(ResultStatus.Aborted)
                                     : Is.Empty);
 
                       Assert.That(outputRoot.Status,

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,15 @@ ENTRYPOINT [ "/tini", "-s", "-vv", "--", "dotnet" ]
 FROM mcr.microsoft.com/dotnet/aspnet:10.0-nanoserver-ltsc2022 AS base-windows
 ENTRYPOINT ["C:\\Program Files\\dotnet\\dotnet.exe"]
 
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build-linux
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-nanoserver-ltsc2022 AS build-windows
+
+# Configure sh for RUN commands
+RUN pwsh -Command "Invoke-WebRequest -Uri https://frippery.org/files/busybox/busybox64u.exe -OutFile 'C:\\Program Files\\busybox.exe'"
+RUN pwsh -Command "Set-Content -Path 'C:\\Program Files\\sh.ps1' -Value '$wrapper = ''\"C:\Program Files\sh.ps1\"''; $cmdLine = [Environment]::CommandLine; $idx = $cmdLine.IndexOf($wrapper) + $wrapper.Length; $cmd = $cmdLine.Substring($idx).TrimStart(); $cmd | & ''C:\Program Files\busybox.exe'' sh'"
+SHELL ["pwsh", "-File", "\"C:\\Program Files\\sh.ps1\""]
+
+FROM build-${BUILDOS} AS build
 ARG VERSION=1.0.0.0
 ARG TARGETARCH
 ARG TARGETOS

--- a/Tests/Bench/Client/src/Dockerfile
+++ b/Tests/Bench/Client/src/Dockerfile
@@ -7,7 +7,15 @@ ENTRYPOINT [ "dotnet" ]
 FROM mcr.microsoft.com/dotnet/aspnet:10.0-nanoserver-ltsc2022 AS base-windows
 ENTRYPOINT ["C:\\Program Files\\dotnet\\dotnet.exe"]
 
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build-linux
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-nanoserver-ltsc2022 AS build-windows
+
+# Configure sh for RUN commands
+RUN pwsh -Command "Invoke-WebRequest -Uri https://frippery.org/files/busybox/busybox64u.exe -OutFile 'C:\\Program Files\\busybox.exe'"
+RUN pwsh -Command "Set-Content -Path 'C:\\Program Files\\sh.ps1' -Value '$wrapper = ''\"C:\Program Files\sh.ps1\"''; $cmdLine = [Environment]::CommandLine; $idx = $cmdLine.IndexOf($wrapper) + $wrapper.Length; $cmd = $cmdLine.Substring($idx).TrimStart(); $cmd | & ''C:\Program Files\busybox.exe'' sh'"
+SHELL ["pwsh", "-File", "\"C:\\Program Files\\sh.ps1\""]
+
+FROM build-${BUILDOS} AS build
 ARG TARGETARCH
 ARG TARGETOS
 ARG VERSION=1.0.0.0

--- a/Tests/Bench/Server/src/Dockerfile
+++ b/Tests/Bench/Server/src/Dockerfile
@@ -7,7 +7,15 @@ ENTRYPOINT [ "dotnet" ]
 FROM mcr.microsoft.com/dotnet/aspnet:10.0-nanoserver-ltsc2022 AS base-windows
 ENTRYPOINT ["C:\\Program Files\\dotnet\\dotnet.exe"]
 
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build-linux
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-nanoserver-ltsc2022 AS build-windows
+
+# Configure sh for RUN commands
+RUN pwsh -Command "Invoke-WebRequest -Uri https://frippery.org/files/busybox/busybox64u.exe -OutFile 'C:\\Program Files\\busybox.exe'"
+RUN pwsh -Command "Set-Content -Path 'C:\\Program Files\\sh.ps1' -Value '$wrapper = ''\"C:\Program Files\sh.ps1\"''; $cmdLine = [Environment]::CommandLine; $idx = $cmdLine.IndexOf($wrapper) + $wrapper.Length; $cmd = $cmdLine.Substring($idx).TrimStart(); $cmd | & ''C:\Program Files\busybox.exe'' sh'"
+SHELL ["pwsh", "-File", "\"C:\\Program Files\\sh.ps1\""]
+
+FROM build-${BUILDOS} AS build
 ARG TARGETARCH
 ARG TARGETOS
 ARG VERSION=1.0.0.0

--- a/Tests/CrashingWorker/Client/src/Dockerfile
+++ b/Tests/CrashingWorker/Client/src/Dockerfile
@@ -7,7 +7,15 @@ ENTRYPOINT [ "dotnet" ]
 FROM mcr.microsoft.com/dotnet/aspnet:10.0-nanoserver-ltsc2022 AS base-windows
 ENTRYPOINT ["C:\\Program Files\\dotnet\\dotnet.exe"]
 
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build-linux
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-nanoserver-ltsc2022 AS build-windows
+
+# Configure sh for RUN commands
+RUN pwsh -Command "Invoke-WebRequest -Uri https://frippery.org/files/busybox/busybox64u.exe -OutFile 'C:\\Program Files\\busybox.exe'"
+RUN pwsh -Command "Set-Content -Path 'C:\\Program Files\\sh.ps1' -Value '$wrapper = ''\"C:\Program Files\sh.ps1\"''; $cmdLine = [Environment]::CommandLine; $idx = $cmdLine.IndexOf($wrapper) + $wrapper.Length; $cmd = $cmdLine.Substring($idx).TrimStart(); $cmd | & ''C:\Program Files\busybox.exe'' sh'"
+SHELL ["pwsh", "-File", "\"C:\\Program Files\\sh.ps1\""]
+
+FROM build-${BUILDOS} AS build
 ARG TARGETARCH
 ARG TARGETOS
 ARG VERSION=1.0.0.0

--- a/Tests/CrashingWorker/Server/src/Dockerfile
+++ b/Tests/CrashingWorker/Server/src/Dockerfile
@@ -7,7 +7,15 @@ ENTRYPOINT [ "dotnet" ]
 FROM mcr.microsoft.com/dotnet/aspnet:10.0-nanoserver-ltsc2022 AS base-windows
 ENTRYPOINT ["C:\\Program Files\\dotnet\\dotnet.exe"]
 
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build-linux
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-nanoserver-ltsc2022 AS build-windows
+
+# Configure sh for RUN commands
+RUN pwsh -Command "Invoke-WebRequest -Uri https://frippery.org/files/busybox/busybox64u.exe -OutFile 'C:\\Program Files\\busybox.exe'"
+RUN pwsh -Command "Set-Content -Path 'C:\\Program Files\\sh.ps1' -Value '$wrapper = ''\"C:\Program Files\sh.ps1\"''; $cmdLine = [Environment]::CommandLine; $idx = $cmdLine.IndexOf($wrapper) + $wrapper.Length; $cmd = $cmdLine.Substring($idx).TrimStart(); $cmd | & ''C:\Program Files\busybox.exe'' sh'"
+SHELL ["pwsh", "-File", "\"C:\\Program Files\\sh.ps1\""]
+
+FROM build-${BUILDOS} AS build
 ARG TARGETARCH
 ARG TARGETOS
 ARG VERSION=1.0.0.0

--- a/Tests/HtcMock/Client/src/Dockerfile
+++ b/Tests/HtcMock/Client/src/Dockerfile
@@ -7,7 +7,15 @@ ENTRYPOINT [ "dotnet" ]
 FROM mcr.microsoft.com/dotnet/aspnet:10.0-windowsservercore-ltsc2022 AS base-windows
 ENTRYPOINT ["C:\\Program Files\\dotnet\\dotnet.exe"]
 
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build-linux
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-nanoserver-ltsc2022 AS build-windows
+
+# Configure sh for RUN commands
+RUN pwsh -Command "Invoke-WebRequest -Uri https://frippery.org/files/busybox/busybox64u.exe -OutFile 'C:\\Program Files\\busybox.exe'"
+RUN pwsh -Command "Set-Content -Path 'C:\\Program Files\\sh.ps1' -Value '$wrapper = ''\"C:\Program Files\sh.ps1\"''; $cmdLine = [Environment]::CommandLine; $idx = $cmdLine.IndexOf($wrapper) + $wrapper.Length; $cmd = $cmdLine.Substring($idx).TrimStart(); $cmd | & ''C:\Program Files\busybox.exe'' sh'"
+SHELL ["pwsh", "-File", "\"C:\\Program Files\\sh.ps1\""]
+
+FROM build-${BUILDOS} AS build
 ARG TARGETARCH
 ARG TARGETOS
 ARG VERSION=1.0.0.0

--- a/Tests/HtcMock/Server/src/Dockerfile
+++ b/Tests/HtcMock/Server/src/Dockerfile
@@ -7,7 +7,15 @@ ENTRYPOINT [ "dotnet" ]
 FROM mcr.microsoft.com/dotnet/aspnet:10.0-nanoserver-ltsc2022 AS base-windows
 ENTRYPOINT ["C:\\Program Files\\dotnet\\dotnet.exe"]
 
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build-linux
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-nanoserver-ltsc2022 AS build-windows
+
+# Configure sh for RUN commands
+RUN pwsh -Command "Invoke-WebRequest -Uri https://frippery.org/files/busybox/busybox64u.exe -OutFile 'C:\\Program Files\\busybox.exe'"
+RUN pwsh -Command "Set-Content -Path 'C:\\Program Files\\sh.ps1' -Value '$wrapper = ''\"C:\Program Files\sh.ps1\"''; $cmdLine = [Environment]::CommandLine; $idx = $cmdLine.IndexOf($wrapper) + $wrapper.Length; $cmd = $cmdLine.Substring($idx).TrimStart(); $cmd | & ''C:\Program Files\busybox.exe'' sh'"
+SHELL ["pwsh", "-File", "\"C:\\Program Files\\sh.ps1\""]
+
+FROM build-${BUILDOS} AS build
 ARG TARGETARCH
 ARG TARGETOS
 ARG VERSION=1.0.0.0

--- a/Tests/Stream/Client/Dockerfile
+++ b/Tests/Stream/Client/Dockerfile
@@ -7,7 +7,15 @@ ENTRYPOINT [ "dotnet" ]
 FROM mcr.microsoft.com/dotnet/sdk:10.0-nanoserver-ltsc2022 AS base-windows
 ENTRYPOINT ["C:\\Program Files\\dotnet\\dotnet.exe"]
 
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build-linux
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-nanoserver-ltsc2022 AS build-windows
+
+# Configure sh for RUN commands
+RUN pwsh -Command "Invoke-WebRequest -Uri https://frippery.org/files/busybox/busybox64u.exe -OutFile 'C:\\Program Files\\busybox.exe'"
+RUN pwsh -Command "Set-Content -Path 'C:\\Program Files\\sh.ps1' -Value '$wrapper = ''\"C:\Program Files\sh.ps1\"''; $cmdLine = [Environment]::CommandLine; $idx = $cmdLine.IndexOf($wrapper) + $wrapper.Length; $cmd = $cmdLine.Substring($idx).TrimStart(); $cmd | & ''C:\Program Files\busybox.exe'' sh'"
+SHELL ["pwsh", "-File", "\"C:\\Program Files\\sh.ps1\""]
+
+FROM build-${BUILDOS} AS build
 ARG TARGETARCH
 ARG TARGETOS
 ARG VERSION=1.0.0.0

--- a/Tests/Stream/Server/Dockerfile
+++ b/Tests/Stream/Server/Dockerfile
@@ -7,7 +7,15 @@ ENTRYPOINT [ "dotnet" ]
 FROM mcr.microsoft.com/dotnet/sdk:10.0-nanoserver-ltsc2022 AS base-windows
 ENTRYPOINT ["C:\\Program Files\\dotnet\\dotnet.exe"]
 
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build-linux
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-nanoserver-ltsc2022 AS build-windows
+
+# Configure sh for RUN commands
+RUN pwsh -Command "Invoke-WebRequest -Uri https://frippery.org/files/busybox/busybox64u.exe -OutFile 'C:\\Program Files\\busybox.exe'"
+RUN pwsh -Command "Set-Content -Path 'C:\\Program Files\\sh.ps1' -Value '$wrapper = ''\"C:\Program Files\sh.ps1\"''; $cmdLine = [Environment]::CommandLine; $idx = $cmdLine.IndexOf($wrapper) + $wrapper.Length; $cmd = $cmdLine.Substring($idx).TrimStart(); $cmd | & ''C:\Program Files\busybox.exe'' sh'"
+SHELL ["pwsh", "-File", "\"C:\\Program Files\\sh.ps1\""]
+
+FROM build-${BUILDOS} AS build
 ARG TARGETARCH
 ARG TARGETOS
 ARG VERSION=1.0.0.0

--- a/Utils/src/ByteArrayComparer.cs
+++ b/Utils/src/ByteArrayComparer.cs
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-using System;
 using System.Collections.Generic;
 
 namespace ArmoniK.Core.Utils;

--- a/Utils/src/ByteArrayComparer.cs
+++ b/Utils/src/ByteArrayComparer.cs
@@ -49,7 +49,15 @@ public class ByteArrayComparer : IEqualityComparer<byte[]>
       return false;
     }
 
-    return x.SequenceEqual(y);
+    for (var i = 0; i < x.Length; i++)
+    {
+      if (x[i] != y[i])
+      {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   /// <summary>

--- a/Utils/src/ByteArrayComparer.cs
+++ b/Utils/src/ByteArrayComparer.cs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+using System;
 using System.Collections.Generic;
 
 namespace ArmoniK.Core.Utils;
@@ -49,15 +50,7 @@ public class ByteArrayComparer : IEqualityComparer<byte[]>
       return false;
     }
 
-    for (var i = 0; i < x.Length; i++)
-    {
-      if (x[i] != y[i])
-      {
-        return false;
-      }
-    }
-
-    return true;
+    return x.SequenceEqual(y);
   }
 
   /// <summary>

--- a/Utils/src/ByteArrayComparer.cs
+++ b/Utils/src/ByteArrayComparer.cs
@@ -1,0 +1,86 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2026. All rights reserved.
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+// 
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System.Collections.Generic;
+
+namespace ArmoniK.Core.Utils;
+
+/// <summary>
+///   Comparer for byte[] instances
+/// </summary>
+public class ByteArrayComparer : IEqualityComparer<byte[]>
+{
+  /// <summary>
+  ///   Compares 2 byte[] instances
+  /// </summary>
+  /// <param name="x">First byte[] instance</param>
+  /// <param name="y">Second byte[] instance</param>
+  /// <returns>true when the 2 instances are equal, false otherwise</returns>
+  public bool Equals(byte[]? x,
+                     byte[]? y)
+  {
+    if (ReferenceEquals(x,
+                        y))
+    {
+      return true;
+    }
+
+    if (x == null || y == null)
+    {
+      return false;
+    }
+
+    if (x.Length != y.Length)
+    {
+      return false;
+    }
+
+    for (var i = 0; i < x.Length; i++)
+    {
+      if (x[i] != y[i])
+      {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /// <summary>
+  ///   Compute a hash code for a byte[] instance
+  /// </summary>
+  /// <param name="obj">The byte[] instance</param>
+  /// <returns>The hash code</returns>
+  public int GetHashCode(byte[]? obj)
+  {
+    if (obj == null)
+    {
+      return 0;
+    }
+
+    unchecked
+    {
+      var hash = 17;
+      foreach (var b in obj)
+      {
+        hash = hash * 31 + b;
+      }
+
+      return hash;
+    }
+  }
+}

--- a/terraform/rabbitmq/rabbitmq.conf
+++ b/terraform/rabbitmq/rabbitmq.conf
@@ -13,11 +13,11 @@ log.console = true
 
 ## Defines the threshold of RAM using at which publishers to the queue are throttled
 ## https://www.rabbitmq.com/memory.html
-vm_memory_high_watermark.relative = 0.75
+vm_memory_high_watermark.relative = 0.6
 
 ## Defines the threshold of memory using at which publishers to the queue are throttled 
 ## https://www.rabbitmq.com/disk-alarms.html
-disk_free_limit.relative = 0.75
+disk_free_limit.absolute = 2GB
 
 ## Defines the SSL configuration for RabbitMQ
 ## https://www.rabbitmq.com/docs/ssl.html

--- a/tools/remove_images.py
+++ b/tools/remove_images.py
@@ -28,7 +28,11 @@ def get_tags(token, repository):
     url = f"{BASE_URL}/repositories/{repository}/tags?page_size=100"
     while url:
         response = requests.get(url, headers=headers)
-        response.raise_for_status()
+        if response.status_code == 404:
+            logging.warning(f"Not found for {url}")
+            return
+        else:
+            response.raise_for_status()
         data = response.json()
         url = data.get("next")
         for t in data["results"]:


### PR DESCRIPTION
# Motivation

When a pod crashes while processing a task near completion, other pods might try to handle this crash when they get the task message from the queue. When two pods try to acquire this task at the same time and handle this task simultaneously, they might end up cancelling a task while the other is still checking created subtasks status. Since Armonik heuristics consider that a task must have all subtasks on status creating while its parent task is no completed, in a concurrency case where a task is cancelled during the check of this heuristic, the parent task is considered completed by the other pods and has its status updated on mongo, making it blocked. This causes non-reexecution of this and blocks the workflow for all dependent tasks.

# Description

This PR fixes the race condition by introducing a new PurgeTasksAndAbortResults method that deletes subtasks instead of just cancelling them when a task crashes during processing.

# Testing

Updated unit tasks and global stress tests at CACIB

# Impact

Subtasks from crashed tasks are now deleted instead of marked as cancelled, preventing the race condition that could block the workflow.

# Additional Information

The recursion kept over tasks dependent indrectly might be removed after discussion, it might not be necessary. Results can also be deleted. The intent of this commit is to fix the bug that was locking sessions, keeping the behaviour close as possible.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.
