### PR TITLE
Add new parameter to  Indicates whether to use minimal indexes for th…

### DIFF
--- a/Adaptors/MongoDB/src/Options/MongoDB.cs
+++ b/Adaptors/MongoDB/src/Options/MongoDB.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2025. All rights reserved.
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -135,4 +135,10 @@ public class MongoDB
   ///   Authentication source for the MongoDB connection.
   /// </summary>
   public string AuthSource { get; set; } = "";
+
+  /// <summary>
+  ///   Indicates whether to use minimal indexes for the collections.
+  /// </summary>
+  public bool UseMinimalIndexes { get; set; } = false;
+
 }

--- a/Adaptors/MongoDB/src/Table/DataModel/TaskDataModelMapping.cs
+++ b/Adaptors/MongoDB/src/Table/DataModel/TaskDataModelMapping.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2025. All rights reserved.
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -191,24 +191,30 @@ public class TaskDataModelMapping : IMongoDataModelMapping<TaskData>
                                            IMongoCollection<TaskData> collection,
                                            Options.MongoDB            options)
   {
-    var indexModels = new[]
+    var indexModels = new List<CreateIndexModel<TaskData>>
                       {
                         IndexHelper.CreateHashedIndex<TaskData>(model => model.Status),
                         IndexHelper.CreateHashedIndex<TaskData>(model => model.Options.PartitionId),
                         IndexHelper.CreateHashedIndex<TaskData>(model => model.SessionId),
-                        IndexHelper.CreateHashedIndex<TaskData>(model => model.OwnerPodId),
                         IndexHelper.CreateHashedIndex<TaskData>(model => model.InitialTaskId),
                         IndexHelper.CreateHashedIndex<TaskData>(model => model.CreatedBy),
-                        IndexHelper.CreateAscendingIndex<TaskData>(model => model.CreationDate,
-                                                                   expireAfter: options.DataRetention),
-                        IndexHelper.CreateAscendingIndex<TaskData>(model => model.SubmittedDate),
-                        IndexHelper.CreateAscendingIndex<TaskData>(model => model.StartDate),
-                        IndexHelper.CreateAscendingIndex<TaskData>(model => model.EndDate),
-                        IndexHelper.CreateAscendingIndex<TaskData>(model => model.CreationToEndDuration),
-                        IndexHelper.CreateAscendingIndex<TaskData>(model => model.ProcessingToEndDuration),
                         IndexHelper.CreateCombinedIndex<TaskData>(model => model.Options.PartitionId,
                                                                   model => model.Status),
                       };
+
+    if (options.UseMinimalIndexes == false)
+    {
+        indexModels.AddRange([
+          IndexHelper.CreateHashedIndex<TaskData>(model => model.OwnerPodId),
+          IndexHelper.CreateAscendingIndex<TaskData>(model => model.CreationDate,
+                                                     expireAfter: options.DataRetention),
+          IndexHelper.CreateAscendingIndex<TaskData>(model => model.SubmittedDate),
+          IndexHelper.CreateAscendingIndex<TaskData>(model => model.StartDate),
+          IndexHelper.CreateAscendingIndex<TaskData>(model => model.EndDate),
+          IndexHelper.CreateAscendingIndex<TaskData>(model => model.CreationToEndDuration),
+          IndexHelper.CreateAscendingIndex<TaskData>(model => model.ProcessingToEndDuration),
+        ]);
+    }
 
     await collection.Indexes.CreateManyAsync(sessionHandle,
                                              indexModels)

--- a/Adaptors/MongoDB/src/TaskTable.cs
+++ b/Adaptors/MongoDB/src/TaskTable.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2025. All rights reserved.
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -409,9 +409,15 @@ public class TaskTable : BaseTable<TaskData, TaskDataModelMapping>, ITaskTable
                                          cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
 
-    var readyTasks = taskCollection.Find(sessionHandle,
-                                         data => taskIds.Contains(data.TaskId) && (data.Status == TaskStatus.Creating || data.Status == TaskStatus.Pending) &&
-                                                 data.RemainingDataDependencies == new Dictionary<string, bool>())
+    var emptyDictionary = new Dictionary<string, bool>();
+
+    var filter =   Builders<TaskData>.Filter.In(t => t.TaskId, taskIds)
+                 & Builders<TaskData>.Filter.Or(Builders<TaskData>.Filter.Eq(t => t.Status, TaskStatus.Creating),
+                                                          Builders<TaskData>.Filter.Eq(t => t.Status,TaskStatus.Pending))
+                 & Builders<TaskData>.Filter.Eq(t => t.RemainingDataDependencies,
+                                                emptyDictionary);
+
+    var readyTasks = taskCollection.Find(filter)
                                    .Project(selector)
                                    .ToAsyncEnumerable(cancellationToken);
 

--- a/Compute/PollingAgent/src/appsettings.json
+++ b/Compute/PollingAgent/src/appsettings.json
@@ -30,7 +30,8 @@
     },
     "ObjectStorage": {
       "ChunkSize": "100000"
-    }
+    },
+    "UseMinimalIndexes" : true
   },
   "Amqp": {
     "MaxRetries": "10",

--- a/Control/Metrics/src/appsettings.json
+++ b/Control/Metrics/src/appsettings.json
@@ -28,7 +28,8 @@
     },
     "ObjectStorage": {
       "ChunkSize": "100000"
-    }
+    },
+    "UseMinimalIndexes": true
   },
   "Amqp": {
     "MaxRetries": "10",

--- a/Control/PartitionMetrics/src/appsettings.json
+++ b/Control/PartitionMetrics/src/appsettings.json
@@ -33,7 +33,8 @@
       "LockRefreshPeriodicity": "00:20:00",
       "PollPeriodicity": "00:00:50",
       "LockRefreshExtension": "00:50:00"
-    }
+    },
+    "UseMinimalIndexes": true
   },
   "Amqp": {
     "MaxRetries": "10",

--- a/Control/Submitter/src/appsettings.json
+++ b/Control/Submitter/src/appsettings.json
@@ -31,7 +31,8 @@
     },
     "ObjectStorage": {
       "ChunkSize": "100000"
-    }
+    },
+    "UseMinimalIndexes": true
   },
   "Amqp": {
     "MaxRetries": "10",


### PR DESCRIPTION
Add new parameter to  Indicates whether to use minimal indexes for the collection

and rework on ReadyTask query to use Mongo query language

# Motivation

Idea is to not create only indexes on TaskData needed for Armonik computation, and then not create all indexes included ones needed for monitoring

# Description

Add new parameter on MongoDB section in appSetting: UseMinimalIndexes
if st to true, then create only needed indexes for backend

# Testing



# Impact

When we create less indexes the is an impact on BulkInsert , this will consume less time to insert TaskData

# Additional Information

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
